### PR TITLE
Add a dbus method to find all the uid in a query without pagination

### DIFF
--- a/src/carquinyol/datastore.py
+++ b/src/carquinyol/datastore.py
@@ -443,6 +443,24 @@ class DataStore(dbus.service.Object):
             else:
                 metadata['filesize'] = '0'
 
+
+    @dbus.service.method(DS_DBUS_INTERFACE,
+             in_signature='a{sv}',
+             out_signature='as')
+    def find_ids(self, query):
+        logging.error('datastore.find_ids %r', query)
+
+        if not self._index_updating:
+            try:
+                #query['offset'] = 0
+                #query['limit'] = MAX_QUERY_LIMIT
+                return self._index_store.find(query)[0]
+            except Exception:
+                logging.error('Failed to query index, will rebuild')
+                self._rebuild_index()
+        return []
+
+
     @dbus.service.method(DS_DBUS_INTERFACE,
              in_signature='s',
              out_signature='s',


### PR DESCRIPTION
This is needed by the journal to implement the multi operations
feature. Without this, when the user "select all", the model is
transversed and query the datastore several times, depending
on the content of the journal and the page size (10).

Signed-off-by: Gonzalo Odiard gonzalo@laptop.org
