### PR TITLE
Port optparse to argparse

### DIFF
--- a/bin/copy-from-journal
+++ b/bin/copy-from-journal
@@ -6,8 +6,9 @@
 
 import os
 import shutil
-import argparse
+from sugar_argparser import SugarArgumentParser
 import dbus
+
 
 if os.path.exists("/tmp/olpc-session-bus"):
     os.environ["DBUS_SESSION_BUS_ADDRESS"] = "unix:path=/tmp/olpc-session-bus"
@@ -23,7 +24,7 @@ RETURN_LIMIT = 2
 def build_argument_parser():
 
     usage = "%(prog)s [-o OBJECT_ID] [-q SEARCH_STR] [-m] OUTFILE"
-    parser = argparse.ArgumentParser(usage=usage)
+    parser = SugarArgumentParser(usage=usage)
 
     parser.add_argument('outfile',
                       help="Name the output file with the explicit name",
@@ -47,9 +48,6 @@ if __name__ == "__main__":
 
     argument_parser = build_argument_parser()
     args = argument_parser.parse_args()
-    if not args.outfile:
-        argument_parser.print_help()
-        exit(0)
 
     try:
         dsentry = None

--- a/bin/copy-from-journal
+++ b/bin/copy-from-journal
@@ -71,8 +71,8 @@ if __name__ == "__main__":
             objects, count = \
                     datastore.find(query, limit=RETURN_LIMIT, sorting='-mtime')
             if count > 1:
-                print('WARNING: %d objects found; getting most recent.' % count)
-                for i in range(1, RETURN_LIMIT):
+                print 'WARNING: %d objects found; getting most recent.' % count
+                for i in xrange(1, RETURN_LIMIT):
                     objects[i].destroy()
 
             if count > 0:
@@ -80,20 +80,20 @@ if __name__ == "__main__":
 
         # If neither an explicit object ID nor a query gave us data, fail.
         if dsentry is None:
-            print('ERROR: unable to determine journal object to copy.')
+            print 'ERROR: unable to determine journal object to copy.'
             argument_parser.print_help()
             exit(0)
 
         # Print metadata if that is what the user asked for.
         if args.show_meta:
-            print('Metadata:')
+            print 'Metadata:'
             for key, val in dsentry.metadata.get_dictionary().iteritems():
                 if key != 'preview':
-                    print('%20s -> %s' % (key, val))
+                    print '%20s -> %s' % (key, val)
 
         # If no file is associated with this object, we can't save it out.
         if dsentry.get_file_path() == "":
-            print('ERROR: no file associated with object, just metadata.')
+            print 'ERROR: no file associated with object, just metadata.'
             dsentry.destroy()
             exit(0)
 
@@ -105,22 +105,22 @@ if __name__ == "__main__":
         if outext == "":
             mimetype = dsentry.metadata['mime_type']
             outext = sugar.mime.get_primary_extension(mimetype)
-            if outext is None:
+            if outext == None:
                 outext = "dsobject"
             outext = '.' + outext
 
         # Lastly, actually copy the file out of the datastore and onto the
         # filesystem.
         shutil.copyfile(dsentry.get_file_path(), outroot + outext)
-        print('%s -> %s' % (dsentry.get_file_path(), outroot + outext))
+        print '%s -> %s' % (dsentry.get_file_path(), outroot + outext)
 
         # Cleanup.
         dsentry.destroy()
 
     except dbus.DBusException:
-        print('ERROR: Unable to connect to the datastore.\n'\
+        print 'ERROR: Unable to connect to the datastore.\n'\
               'Check that you are running in the same environment as the '\
-              'datastore service.')
+              'datastore service.'
 
-    except Exception as e:
-        print('ERROR: %s' % e)
+    except Exception, e:
+        print 'ERROR: %s' % (e)

--- a/bin/copy-from-journal
+++ b/bin/copy-from-journal
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 #
 # Simple script to export a file from the datastore
 # Reinier Heeres, <reinier@heeres.eu>, 2007-12-24
@@ -89,7 +89,7 @@ if __name__ == "__main__":
             print('Metadata:')
             for key, val in dsentry.metadata.get_dictionary().iteritems():
                 if key != 'preview':
-                    print ('%20s -> %s' % (key, val))
+                    print('%20s -> %s' % (key, val))
 
         # If no file is associated with this object, we can't save it out.
         if dsentry.get_file_path() == "":
@@ -105,7 +105,7 @@ if __name__ == "__main__":
         if outext == "":
             mimetype = dsentry.metadata['mime_type']
             outext = sugar.mime.get_primary_extension(mimetype)
-            if outext == None:
+            if outext is None:
                 outext = "dsobject"
             outext = '.' + outext
 

--- a/bin/copy-from-journal
+++ b/bin/copy-from-journal
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 #
 # Simple script to export a file from the datastore
 # Reinier Heeres, <reinier@heeres.eu>, 2007-12-24
@@ -6,7 +6,7 @@
 
 import os
 import shutil
-import optparse
+import argparse
 import dbus
 
 if os.path.exists("/tmp/olpc-session-bus"):
@@ -20,20 +20,23 @@ import sugar3.mime
 RETURN_LIMIT = 2
 
 
-def build_option_parser():
+def build_argument_parser():
 
-    usage = "Usage: %prog [-o OBJECT_ID] [-q SEARCH_STR] [-m] OUTFILE"
-    parser = optparse.OptionParser(usage=usage)
+    usage = "%(prog)s [-o OBJECT_ID] [-q SEARCH_STR] [-m] OUTFILE"
+    parser = argparse.ArgumentParser(usage=usage)
 
-    parser.add_option("-o", "--object_id", action="store", dest="object_id",
+    parser.add_argument('outfile',
+                      help="Name the output file with the explicit name",
+                      metavar="OUTFILE")
+    parser.add_argument("-o", "--object_id", action="store", dest="object_id",
                       help="Retrieve object with explicit ID OBJECT_ID",
                       metavar="OBJECT_ID", default=None)
 
-    parser.add_option("-q", "--query", action="store", dest="query",
+    parser.add_argument("-q", "--query", action="store", dest="query",
                       help="Full-text-search the metadata for SEARCH_STR",
                       metavar="SEARCH_STR", default=None)
 
-    parser.add_option("-m", "--metadata", action="store_true",
+    parser.add_argument("-m", "--metadata", action="store_true",
             dest="show_meta",
             help="Show all non-preview metadata [default: hide]",
             default=False)
@@ -42,25 +45,25 @@ def build_option_parser():
 
 if __name__ == "__main__":
 
-    option_parser = build_option_parser()
-    options, args = option_parser.parse_args()
-    if len(args) < 1:
-        option_parser.print_help()
+    argument_parser = build_argument_parser()
+    args = argument_parser.parse_args()
+    if not args.outfile:
+        argument_parser.print_help()
         exit(0)
 
     try:
         dsentry = None
 
         # Get object directly if we were given an explicit object ID.
-        if options.object_id is not None:
-            dsentry = datastore.get(options.object_id)
+        if args.object_id is not None:
+            dsentry = datastore.get(args.object_id)
 
         # Compose the query based on the options provided.
         if dsentry is None:
             query = {}
 
-            if options.query is not None:
-                query['query'] = options.query
+            if args.query is not None:
+                query['query'] = args.query
 
             # We only want a single file at a time; limit the number of objects
             # returned to two, as anything more than one means the criteria
@@ -68,8 +71,8 @@ if __name__ == "__main__":
             objects, count = \
                     datastore.find(query, limit=RETURN_LIMIT, sorting='-mtime')
             if count > 1:
-                print 'WARNING: %d objects found; getting most recent.' % count
-                for i in xrange(1, RETURN_LIMIT):
+                print('WARNING: %d objects found; getting most recent.' % count)
+                for i in range(1, RETURN_LIMIT):
                     objects[i].destroy()
 
             if count > 0:
@@ -77,24 +80,24 @@ if __name__ == "__main__":
 
         # If neither an explicit object ID nor a query gave us data, fail.
         if dsentry is None:
-            print 'ERROR: unable to determine journal object to copy.'
-            option_parser.print_help()
+            print('ERROR: unable to determine journal object to copy.')
+            argument_parser.print_help()
             exit(0)
 
         # Print metadata if that is what the user asked for.
-        if options.show_meta:
-            print 'Metadata:'
+        if args.show_meta:
+            print('Metadata:')
             for key, val in dsentry.metadata.get_dictionary().iteritems():
                 if key != 'preview':
-                    print '%20s -> %s' % (key, val)
+                    print ('%20s -> %s' % (key, val))
 
         # If no file is associated with this object, we can't save it out.
         if dsentry.get_file_path() == "":
-            print 'ERROR: no file associated with object, just metadata.'
+            print('ERROR: no file associated with object, just metadata.')
             dsentry.destroy()
             exit(0)
 
-        outname = args[0]
+        outname = args.outfile
         outroot, outext = os.path.splitext(outname)
 
         # Do our best to determine the output file extension, based on Sugar's
@@ -109,15 +112,15 @@ if __name__ == "__main__":
         # Lastly, actually copy the file out of the datastore and onto the
         # filesystem.
         shutil.copyfile(dsentry.get_file_path(), outroot + outext)
-        print '%s -> %s' % (dsentry.get_file_path(), outroot + outext)
+        print('%s -> %s' % (dsentry.get_file_path(), outroot + outext))
 
         # Cleanup.
         dsentry.destroy()
 
     except dbus.DBusException:
-        print 'ERROR: Unable to connect to the datastore.\n'\
+        print('ERROR: Unable to connect to the datastore.\n'\
               'Check that you are running in the same environment as the '\
-              'datastore service.'
+              'datastore service.')
 
-    except Exception, e:
-        print 'ERROR: %s' % (e)
+    except Exception as e:
+        print('ERROR: %s' % e)

--- a/bin/copy-to-journal
+++ b/bin/copy-to-journal
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 #
 # Simple script to import a file to the datastore
 # Reinier Heeres, <reinier@heeres.eu>, 2007-12-20

--- a/bin/copy-to-journal
+++ b/bin/copy-to-journal
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Simple script to import a file to the datastore
 # Reinier Heeres, <reinier@heeres.eu>, 2007-12-20
@@ -8,7 +8,7 @@
 # as otherwise the datastore will not accept the file.
 
 import os
-import optparse
+import argparse
 from gettext import gettext as _
 import dbus
 
@@ -21,22 +21,23 @@ from sugar3 import mime
 
 def build_option_parser():
 
-    usage = "Usage: %prog <file> [-m MIMETYPE] [-t TITLE] [-d DESC] " \
+    usage = "%(prog)s <file> [-m MIMETYPE] [-t TITLE] [-d DESC] " \
             "[-T tag1 [-T tag2 ...]]"
-    parser = optparse.OptionParser(usage=usage)
+    parser = argparse.ArgumentParser(usage=usage)
 
-    parser.add_option("-t", "--title", action="store", dest="title",
+    parser.add_argument("file", help="File to be copied to journal")
+    parser.add_argument("-t", "--title", action="store", dest="title",
      help="Set the title of the journal entry to TITLE", metavar="TITLE",
      default=None)
-    parser.add_option("-d", "--description", action="store",
+    parser.add_argument("-d", "--description", action="store",
      dest="description", metavar="DESC",
      help="Set the description of the journal entry to DESC",
      default=None)
-    parser.add_option("-m", "--mimetype", action="store",
+    parser.add_argument("-m", "--mimetype", action="store",
      dest="mimetype", metavar="MIMETYPE",
      help="Set the file's MIME-type to MIMETYPE",
      default=None)
-    parser.add_option("-T", "--tag", action="append", dest="tag_list",
+    parser.add_argument("-T", "--tag", action="append", dest="tag_list",
      help="Add tag TAG to the journal entry's tags; " \
              "this option can be repeated",
      metavar="TAG")
@@ -44,17 +45,17 @@ def build_option_parser():
 
 if __name__ == "__main__":
 
-    option_parser = build_option_parser()
-    options, args = option_parser.parse_args()
-    if len(args) < 1:
-        option_parser.print_help()
+    argument_parser = build_option_parser()
+    args = argument_parser.parse_args()
+    if not args.file:
+        argument_parser.print_help()
         exit(0)
 
-    fname = args[0]
+    fname = args.file
     absname = os.path.abspath(fname)
     if not os.path.exists(absname):
-        print 'Error: File does not exist.'
-        option_parser.print_help()
+        print('Error: File does not exist.')
+        argument_parser.print_help()
         exit(0)
 
     try:
@@ -62,38 +63,38 @@ if __name__ == "__main__":
         entry.set_file_path(absname)
 
         # Set the mimetype to the provided one.
-        if options.mimetype is None:
+        if args.mimetype is None:
             entry.metadata['mime_type'] = mime.get_for_file(absname)
         else:
-            entry.metadata['mime_type'] = options.mimetype
+            entry.metadata['mime_type'] = args.mimetype
 
         # If no title is given, use the filename.
-        if options.title:
-            entry.metadata['title'] = options.title
+        if args.title:
+            entry.metadata['title'] = args.title
         else:
             entry.metadata['title'] = os.path.basename(fname)
 
         # Use the description given, otherwise leave it blank.
-        if options.description:
-            entry.metadata['description'] = options.description
+        if args.description:
+            entry.metadata['description'] = args.description
         else:
             entry.metadata['description'] = _('From: %s') % fname
 
         # Lastly, if any tags are given, combine them into a single string
         # and save them.
-        if options.tag_list:
-            tag_string = " ".join(options.tag_list)
+        if args.tag_list:
+            tag_string = " ".join(args.tag_list)
             entry.metadata['tags'] = tag_string
 
         datastore.write(entry)
-        print 'Created as %s' % (entry.object_id)
+        print('Created as %s' % (entry.object_id))
 
         entry.destroy()
 
     except dbus.DBusException:
-        print 'ERROR: Unable to connect to the datastore.\n'\
+        print('ERROR: Unable to connect to the datastore.\n'\
               'Check that you are running in the same environment as the '\
-              'datastore service.'
+              'datastore service.')
 
-    except Exception, e:
-        print 'ERROR: %s' % (e)
+    except Exception as e:
+        print('ERROR: %s' % (e))

--- a/bin/copy-to-journal
+++ b/bin/copy-to-journal
@@ -8,7 +8,7 @@
 # as otherwise the datastore will not accept the file.
 
 import os
-import argparse
+from sugar_argparser import SugarArgumentParser
 from gettext import gettext as _
 import dbus
 
@@ -23,7 +23,7 @@ def build_option_parser():
 
     usage = "%(prog)s <file> [-m MIMETYPE] [-t TITLE] [-d DESC] " \
             "[-T tag1 [-T tag2 ...]]"
-    parser = argparse.ArgumentParser(usage=usage)
+    parser = SugarArgumentParser(usage=usage)
 
     parser.add_argument("file", help="File to be copied to journal")
     parser.add_argument("-t", "--title", action="store", dest="title",

--- a/bin/copy-to-journal
+++ b/bin/copy-to-journal
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/python
 #
 # Simple script to import a file to the datastore
 # Reinier Heeres, <reinier@heeres.eu>, 2007-12-20
@@ -54,7 +54,7 @@ if __name__ == "__main__":
     fname = args.file
     absname = os.path.abspath(fname)
     if not os.path.exists(absname):
-        print('Error: File does not exist.')
+        print 'Error: File does not exist.'
         argument_parser.print_help()
         exit(0)
 
@@ -87,14 +87,14 @@ if __name__ == "__main__":
             entry.metadata['tags'] = tag_string
 
         datastore.write(entry)
-        print('Created as %s' % (entry.object_id))
+        print 'Created as %s' % (entry.object_id)
 
         entry.destroy()
 
     except dbus.DBusException:
-        print('ERROR: Unable to connect to the datastore.\n'\
+        print 'ERROR: Unable to connect to the datastore.\n'\
               'Check that you are running in the same environment as the '\
-              'datastore service.')
+              'datastore service.'
 
-    except Exception as e:
-        print('ERROR: %s' % (e))
+    except Exception, e:
+        print 'ERROR: %s' % (e)

--- a/bin/sugar_argparser.py
+++ b/bin/sugar_argparser.py
@@ -1,0 +1,19 @@
+"""Scripts that implements a class that extends ArgumentParser
+and custom the error message.
+"""
+
+import argparse
+
+class SugarArgumentParser(argparse.ArgumentParser):
+    """Class that extends ArgumentParser and calls print_help()
+    if there is an error.
+    """
+
+    def error(self, message):
+        """Prints help if there is an error.
+
+        Args:
+            message. str. The error message.
+        """
+        self.print_help()
+        exit(0)


### PR DESCRIPTION
…urnal
### Explanation
This PR ports optparse to argparse in bin.copy-from-journal and in bin.copy-to-journal. It also ports these files to python3.

### Reason
* optparse is deprecated.

### TODO
 - [x] Run sugar-lint. (Did not found sugar-lint repository).
 - [x] Run tests. (Did not know how to get sugar3 module).