### PR TITLE
Fix empty datastore, data loss

### DIFF
--- a/src/carquinyol/metadatareader.c
+++ b/src/carquinyol/metadatareader.c
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
 #include <dirent.h>


### PR DESCRIPTION
On Ubuntu 22.04 (Jammy Jellyfish) beta, with python3 3.10.4-0ubuntu2, activities cannot read journal objects from datastore, which makes Sugar lose all user data.  A datastore DBusException occurs in the Sugar shell and every activity;

```log
dbus.exceptions.DBusException: org.freedesktop.DBus.Python.ValueError: Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/dbus/service.py", line 715, in _message_cb
    retval = candidate_method(self, *args, **keywords)
  File "/usr/lib/python3/dist-packages/carquinyol/datastore.py", line 483, in get_properties
    metadata = self._metadata_store.retrieve(uid)
  File "/usr/lib/python3/dist-packages/carquinyol/metadatastore.py", line 79, in retrieve
    metadata = metadatareader.retrieve(metadata_path, properties)
ValueError: Failed to convert metadata value to bytes
```

The immediate cause was the handling of a C string buffer and an associated length.

In turn this was an API change in CPython 37bb289 ("bpo-40943: PY_SSIZE_T_CLEAN required for '#' formats (GH-20784)")

https://github.com/python/cpython/commit/37bb2895561d3e63a631f10875567b4e33b30c07

Fixed by defining PY_SSIZE_T_CLEAN per API note
https://docs.python.org/3/c-api/arg.html#strings-and-buffers

> "For all # variants of formats (s#, y#, etc.), the macro PY_SSIZE_T_CLEAN must be defined before including Python.h. On Python 3.9 and older, the type of the length argument is Py_ssize_t if the PY_SSIZE_T_CLEAN macro is defined, or int otherwise."