### PR TITLE
Report actual DBusException in copy-from-journal

### DIFF
--- a/bin/copy-from-journal
+++ b/bin/copy-from-journal
@@ -120,10 +120,8 @@ if __name__ == "__main__":
         # Cleanup.
         dsentry.destroy()
 
-    except DBusException:
-        print('ERROR: Unable to connect to the datastore.\n'
-              'Check that you are running in the same environment as the '
-              'datastore service.')
+    except DBusException as e:
+        print('ERROR: %s' % (e))
 
     except Exception as e:
         print('ERROR: %s' % (e))


### PR DESCRIPTION
This PR updates copy-from-journal to report the actual DBusException instead of always showing a generic "Unable to connect to the datastore" message.

This improves debugging by showing the real cause of the error.