### PR TITLE
Use Xapian commit method instead of flush

### DIFF
--- a/src/carquinyol/indexstore.py
+++ b/src/carquinyol/indexstore.py
@@ -397,7 +397,7 @@ class IndexStore(object):
 
     def _flush(self, force=False):
         """Called after any database mutation"""
-        logger.debug('IndexStore.flush: force=%r _pending_writes=%r',
+        logger.debug('IndexStore.commit: force=%r _pending_writes=%r',
                       force, self._pending_writes)
 
         self._set_index_updated(False)
@@ -410,11 +410,11 @@ class IndexStore(object):
         if force or self._pending_writes > _FLUSH_THRESHOLD:
             try:
                 logger.debug("Start database flush")
-                self._database.flush()
+                self._database.commit()
                 logger.debug("Completed database flush")
             except Exception as e:
                 logger.exception(e)
-                logger.error("Exception during database.flush()")
+                logger.error("Exception during database.commit()")
                 # bail out to trigger a reindex
                 sys.exit(1)
             self._pending_writes = 0


### PR DESCRIPTION
It was added in Xapian 1.1. `xapian.WritableDatabase.flush()` is deprecated and removed in Xapian 2.0.

This fixes the following error using Xapian 2.0:
```
1782223286.247673 ERROR indexstore: 'WritableDatabase' object has no attribute 'flush'
Traceback (most recent call last):
  File "/usr/lib/python3.14/site-packages/carquinyol/indexstore.py", line 413, in _flush
    self._database.flush()
    ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'WritableDatabase' object has no attribute 'flush'
1782223286.248249 ERROR indexstore: Exception during database.flush()
```
Reference:
https://xapian.org/docs/bindings/python3/xapian.html#xapian.WritableDatabase.commit